### PR TITLE
For Buffers, set the content type to application/octet-stream by default.

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -121,10 +121,22 @@ FormData.prototype._multiPartHeader = function(field, value, options) {
     header += '--' + boundary + FormData.LINE_BREAK +
       'Content-Disposition: form-data; name="' + field + '"';
 
+    // if the provided value is a Buffer treat the value as binary content
+    if (Buffer.isBuffer(value)) {
+      // let the user provide a filename for the buffer.
+      if(options.filename) {
+        header += '; filename="' + options.filename + '"';
+      }
+
+      header += 
+        FormData.LINE_BREAK +
+        'Content-Type: application/octet-stream' + FormData.LINE_BREAK +
+        'Content-Transfer-Encoding: binary';
+
     // fs- and request- streams have path property
     // or use custom filename and/or contentType
     // TODO: Use request's response mime-type
-    if (options.filename || value.path) {
+    } else if (options.filename || value.path) {
       header +=
         '; filename="' + path.basename(options.filename || value.path) + '"' + FormData.LINE_BREAK +
         'Content-Type: ' +  (options.contentType || mime.lookup(options.filename || value.path));

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -128,10 +128,16 @@ FormData.prototype._multiPartHeader = function(field, value, options) {
         header += '; filename="' + options.filename + '"';
       }
 
-      header += 
-        FormData.LINE_BREAK +
-        'Content-Type: application/octet-stream' + FormData.LINE_BREAK +
-        'Content-Transfer-Encoding: binary';
+      header += FormData.LINE_BREAK;
+      // let the user set a custom content-type
+      if (options.contentType) {
+        header += 'Content-Type: ' + options.contentType;
+      } else {
+        header += 'Content-Type: application/octet-stream';
+      }
+
+      // if a buffer is being sent then set the encoding as binary.
+      header += FormData.LINE_BREAK + 'Content-Transfer-Encoding: binary';
 
     // fs- and request- streams have path property
     // or use custom filename and/or contentType

--- a/test/integration/test-buffer-headers.js
+++ b/test/integration/test-buffer-headers.js
@@ -1,0 +1,78 @@
+/*
+test custom filename and content-type of Buffer objects
+re: https://github.com/felixge/node-form-data/issues/54
+*/
+
+var common       = require('../common');
+var assert       = common.assert;
+var http         = require('http');
+var fs           = require('fs');
+
+var FormData     = require(common.dir.lib + '/form_data');
+var IncomingForm = require('formidable').IncomingForm;
+
+var options = {
+  filename: 'buffer.bin',
+  contentType: 'application/custom-type'
+};
+
+var server = http.createServer(function(req, res) {
+
+  var form = new IncomingForm({uploadDir: common.dir.tmp});
+
+  form.parse(req);
+
+  form
+    .on('file', function(name, file) {
+      if (name == 'buffer_two') {
+	assert.strictEqual(file.name, 'buffer_two.bin');
+	assert.strictEqual(file.type, 'application/octet-stream');
+
+      } else if (name == 'buffer_three') {
+	assert.strictEqual(file.name, 'buffer_three.bin');
+	assert.strictEqual(file.type, 'application/custom-type');
+      } else {
+	throw new Error('Error: Unexpected file received.');
+      }
+    })
+    .on('field', function(name, value) {
+      // Verify integrity of data sent.
+      if (name == 'buffer_one') {
+	assert.strictEqual(value, 'ABCD');
+      }
+    })
+    .on('end', function() {
+      res.writeHead(200);
+      res.end('done');
+    });
+});
+
+
+server.listen(common.port, function() {
+  var form = new FormData();
+  // A buffer with the string 'ABCD' enconded with ASCII decimal values.
+  var buffer = new Buffer([65, 66, 67, 68]);
+
+  // Test for the default content type
+  form.append('buffer_one', buffer);
+  // Test for the usage of custom filename.
+  form.append('buffer_two' , buffer, 
+	      {filename: 'buffer_two.bin'});
+  // Test for the correct usage of custom content-type.
+  form.append('buffer_three' , buffer, 
+	      {filename: 'buffer_three.bin', contentType: 'application/custom-type'});
+
+  form.submit('http://localhost:' + common.port + '/', function(err, res) {
+    if (err) {
+      throw err;
+    }
+
+    assert.strictEqual(res.statusCode, 200);
+
+    // unstuck new streams
+    res.resume();
+
+    server.close();
+  });
+
+});


### PR DESCRIPTION
When buffers are attached to a form they were added with no content type; therefore, the content type would default to 'text/plan'. This modification changes this behaviour to default to 'application/octet-stream' for buffers.
The user is also able to add a 'filename' optional field to the header in case a file is being sent in binary form.