### PR TITLE
Add shim for browser.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,1 @@
+module.exports = FormData;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/felixge/node-form-data.git"
   },
   "main": "./lib/form_data",
+  "browser": "./lib/browser",
   "scripts": {
     "test": "node test/run.js"
   },


### PR DESCRIPTION
If this module is used with browserify or webpack then we just return the native FormData.
Perhaps in the future we can provide some kind of polyfill instead?